### PR TITLE
class closedMenu was breaking the entire MOBILE page - fixed!

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1574,6 +1574,7 @@ ul {
 }
 .menuClosed {
     display: flex;
+    visibility: hidden;
     flex-direction: column;
     gap: 30px;
     padding: 20px 10px 10px 40px;
@@ -1599,6 +1600,7 @@ ul {
 }
 .menuOpen {
     display: flex;
+    visibility: visible;
     flex-direction: column;
     gap: 5px;
     padding: 15px 30px 10px 30px;
@@ -1635,6 +1637,7 @@ ul {
     padding: 0 15px;
     width: auto;
     overflow: hidden;
+    height: 6800px;
 }
 /*====================================================*/
 /*--------------WELCOME - MOBILE----------------------*/


### PR DESCRIPTION
While the menu for the MOBILE site was set to opacity:0, it was still present and occupied space in the viewport.  This effectively blocked any interactivity with anchor links and some JS event triggers like onClick on certain elements.  First, I changed display from flex to none, which solved the problem, but took away the weird growing-in and flash fade-out animations for the menu.  I, instead, changed display back to flex and added visibility:hidden to the closed state of the menu.  In order for this work, I had to add visibility:visible to the opened state of the menu.  This solved the issue of blocking interactivity.  
I was also having an issue with odd scroll behavior which modifying the menu visibility resolved.  The main scrolling container was limiting its height property to around 5800 - 5900px tall and I could not figure out why.  This either cut off the welcome section content, or the footer and it also created two y-axis scrollbars on top of one another which caused unpredictable scroll behaviour.  I did not want to have a set height for the entire scroll container due to concerns about adding more content in the future, or display on window resizes/ different screen-sized devices.  This issue was resolved before being documented on the repository issue list.